### PR TITLE
Print the error message to console

### DIFF
--- a/pymba/vimbaexception.py
+++ b/pymba/vimbaexception.py
@@ -58,3 +58,5 @@ class VimbaException(Exception):
             self._errorCode = errorCode
         else:
             self._errorCode = -1000
+
+        super(VimbaException, self).__init__(self.message)


### PR DESCRIPTION
The error message is now printed when an exception occurs

    # [...]
        raise VimbaException(errorCode)
    pymba.vimbaexception.VimbaException: Operation is invalid with the current access mode.