### PR TITLE
Fixes PIXEL_FORMATS names for types BayerGR8 and BayerGR12.

### DIFF
--- a/pymba/vimbaframe.py
+++ b/pymba/vimbaframe.py
@@ -22,6 +22,8 @@ PIXEL_FORMATS = {
     "YUV411Packed": 4/3.0,  # ?
     "YUV422Packed": 2,
     "YUV444Packed": 3,
+    "BayerRG8": 1,
+    "BayerRG12": 2,
     "BayerGR8": 1,
     "BayerGR12": 2,
     "BayerGR12Packed": 1.5,  # ?

--- a/pymba/vimbaframe.py
+++ b/pymba/vimbaframe.py
@@ -22,8 +22,8 @@ PIXEL_FORMATS = {
     "YUV411Packed": 4/3.0,  # ?
     "YUV422Packed": 2,
     "YUV444Packed": 3,
-    "BayerRG8": 1,
-    "BayerRG12": 2,
+    "BayerGR8": 1,
+    "BayerGR12": 2,
     "BayerGR12Packed": 1.5,  # ?
 }
 


### PR DESCRIPTION
Fixes PIXEL_FORMATS name for types BayerGR8 and BayerGR12. They had RG instead of GR on vimbaframe.py, which caused an exception when using this pixel formats.