### PR TITLE
Search for Windows DLL instead of hard-coding.

### DIFF
--- a/pymba/vimbadll.py
+++ b/pymba/vimbadll.py
@@ -7,12 +7,19 @@ import os
 from ctypes import *
 
 if sys_plat == "win32":
+
+    def find_win_dll(arch):
+        """ Finds the highest versioned windows dll for the specified architecture. """
+        base = r'C:\Program Files\Allied Vision Technologies\AVTVimba_1.%i\VimbaC\Bin\Win%i\VimbaC.dll'
+        dlls = [base % (i, arch) for i in range(10) if os.path.isfile(base % (i, arch)) ]
+        return dlls[-1]
+
     from ctypes.util import find_msvcrt
     _cruntime = cdll.LoadLibrary(find_msvcrt())
     if '64' in platform.architecture()[0]:
-        vimbaC_path = r'C:\Program Files\Allied Vision Technologies\AVTVimba_1.3\VimbaC\Bin\Win64\VimbaC.dll'
+        vimbaC_path = find_win_dll(64)
     else:
-        vimbaC_path = r'C:\Program Files\Allied Vision Technologies\AVTVimba_1.3\VimbaC\Bin\Win32\VimbaC.dll'
+        vimbaC_path = find_win_dll(32)
     dll_loader = windll
 else:
     _cruntime = CDLL("libc.so.6")

--- a/pymba/vimbadll.py
+++ b/pymba/vimbadll.py
@@ -12,6 +12,8 @@ if sys_plat == "win32":
         """ Finds the highest versioned windows dll for the specified architecture. """
         base = r'C:\Program Files\Allied Vision Technologies\AVTVimba_1.%i\VimbaC\Bin\Win%i\VimbaC.dll'
         dlls = [base % (i, arch) for i in range(10) if os.path.isfile(base % (i, arch)) ]
+        if not dlls:
+            raise IOError("VimbaC.dll not found.")
         return dlls[-1]
 
     from ctypes.util import find_msvcrt


### PR DESCRIPTION
Since Vimba released version 1.4, I think we should get away from hard-coding the path to the DLL.  I have added a function that searches for the dll that should work until they change their folder structure.  I also have systems using version 1.2 still, so I need a solution that works for multiple versions.