### PR TITLE
Initial python 3 support

### DIFF
--- a/pymba/__init__.py
+++ b/pymba/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
-from vimba import Vimba
-from vimbaexception import VimbaException
+from __future__ import absolute_import
+from .vimba import Vimba
+from .vimbaexception import VimbaException
 

--- a/pymba/tests/opencv_example.py
+++ b/pymba/tests/opencv_example.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function, division
 from pymba import *
 import numpy as np
 import cv2
@@ -16,7 +17,7 @@ with Vimba() as vimba:
         time.sleep(0.2)
     cameraIds = vimba.getCameraIds()
     for cameraId in cameraIds:
-        print 'Camera ID:', cameraId
+        print('Camera ID:', cameraId)
 
     # get and open a camera
     camera0 = vimba.getCamera(cameraIds[0])
@@ -25,7 +26,7 @@ with Vimba() as vimba:
     # list camera features
     cameraFeatureNames = camera0.getFeatureNames()
     for name in cameraFeatureNames:
-        print 'Camera feature:', name
+        print('Camera feature:', name)
 
     # read info of a camera feature
     #featureInfo = camera0.getFeatureInfo('AcquisitionMode')
@@ -33,7 +34,7 @@ with Vimba() as vimba:
     #    print field, '--', getattr(featInfo, field)
 
     # get the value of a feature
-    print camera0.AcquisitionMode
+    print(camera0.AcquisitionMode)
 
     # set the value of a feature
     camera0.AcquisitionMode = 'SingleFrame'
@@ -64,7 +65,7 @@ with Vimba() as vimba:
                                                 1))
         rgb = cv2.cvtColor(moreUsefulImgData, cv2.COLOR_BAYER_RG2RGB)
         cv2.imwrite('foo{}.png'.format(count), rgb)
-        print "image {} saved".format(count)
+        print("image {} saved".format(count))
         count += 1
         camera0.endCapture()
     # clean up after capture

--- a/pymba/tests/opencv_liveview_example.py
+++ b/pymba/tests/opencv_liveview_example.py
@@ -5,6 +5,7 @@ Created on Mon Jul 07 14:59:03 2014
 @author: derricw
 """
 
+from __future__ import absolute_import, print_function, division
 from pymba import *
 import numpy as np
 import cv2
@@ -21,15 +22,15 @@ with Vimba() as vimba:
     camera_ids = vimba.getCameraIds()
 
     for cam_id in camera_ids:
-        print "Camera found: ", cam_id
+        print("Camera found: ", cam_id)
         
     c0 = vimba.getCamera(camera_ids[0])
     c0.openCamera()
 
     try:
         #gigE camera
-        print c0.GevSCPSPacketSize
-        print c0.StreamBytesPerSecond
+        print(c0.GevSCPSPacketSize)
+        print(c0.StreamBytesPerSecond)
         c0.StreamBytesPerSecond = 100000000
     except:
         #not a gigE camera
@@ -67,8 +68,8 @@ with Vimba() as vimba:
         k = cv2.waitKey(1)
         if k == 0x1b:
             cv2.destroyAllWindows()
-            print "Frames displayed: %i"%framecount
-            print "Frames dropped: %s"%droppedframes
+            print("Frames displayed: %i"%framecount)
+            print("Frames dropped: %s"%droppedframes)
             break
 
 

--- a/pymba/tests/opencv_liveview_example_color.py
+++ b/pymba/tests/opencv_liveview_example_color.py
@@ -13,7 +13,7 @@ OpenCV is expecting color images to be in BGR8Packed by default.  It can work
     just uses its default behavior.
 
 """
-
+from __future__ import absolute_import, print_function, division
 from pymba import *
 import numpy as np
 import cv2

--- a/pymba/tests/test_cameras.py
+++ b/pymba/tests/test_cameras.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-
+from __future__ import absolute_import, print_function, division
 from pymba import *
 import time
 
@@ -14,9 +14,10 @@ def test_cameras():
         if system.GeVTLIsPresent:
             system.runFeatureCommand("GeVDiscoveryAllOnce")
             time.sleep(0.2)
+
         cameraIds = vimba.getCameraIds()
         for cameraId in cameraIds:
-            print 'Camera ID:', cameraId
+            print('Camera ID:', cameraId)
 
         # get and open a camera
         camera0 = vimba.getCamera(cameraIds[0])
@@ -25,10 +26,10 @@ def test_cameras():
         # list camera features
         cameraFeatureNames = camera0.getFeatureNames()
         for name in cameraFeatureNames:
-            print 'Camera feature:', name
+            print('Camera feature:', name)
 
         # get the value of a feature
-        print camera0.AcquisitionMode
+        print(camera0.AcquisitionMode)
 
         # set the value of a feature
         camera0.AcquisitionMode = 'SingleFrame'
@@ -65,3 +66,7 @@ def test_cameras():
 
         # close camera
         camera0.closeCamera()
+
+
+if __name__ == '__main__':
+    test_cameras()

--- a/pymba/tests/test_installation.py
+++ b/pymba/tests/test_installation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-
+from __future__ import absolute_import, print_function, division
 from pymba import Vimba
 
 

--- a/pymba/tests/test_interfaces.py
+++ b/pymba/tests/test_interfaces.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-
+from __future__ import absolute_import, print_function, division
 from pymba import *
 import time
 
@@ -10,7 +10,7 @@ def test_interfaces():
         # get list of available interfaces
         interfaceIds = vimba.getInterfaceIds()
         for interfaceId in interfaceIds:
-            print 'Interface ID:', interfaceId
+            print('Interface ID:', interfaceId)
 
         # get interface object and open it
         interface0 = vimba.getInterface(interfaceIds[0])
@@ -19,7 +19,10 @@ def test_interfaces():
         # list interface features
         interfaceFeatureNames = interface0.getFeatureNames()
         for name in interfaceFeatureNames:
-            print 'Interface feature:', name
+            print('Interface feature:', name)
 
         # close interface
         interface0.closeInterface()
+
+if __name__ == '__main__':
+    test_interfaces()

--- a/pymba/tests/test_systemfeature.py
+++ b/pymba/tests/test_systemfeature.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-
+from __future__ import absolute_import, print_function, division
 from pymba import *
 
 
@@ -10,9 +10,11 @@ def test_systemfeature():
 
         # list system features
         for featureName in system.getFeatureNames():
-            print 'System feature:', featureName
+            print('System feature:', featureName)
             fInfo = system.getFeatureInfo(featureName)
             for field in fInfo.getFieldNames():
-                print "\t", featureName, ":", field, getattr(fInfo, field)
+                print("\t", featureName, ":", field, getattr(fInfo, field))
 
 
+if __name__ == '__main__':
+    test_systemfeature()

--- a/pymba/vimba.py
+++ b/pymba/vimba.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-import vimbastructure as structs
-from vimbadll import VimbaDLL
-from vimbaexception import VimbaException
-from vimbasystem import VimbaSystem
-from vimbacamera import VimbaCamera
-from vimbainterface import VimbaInterface
+from __future__ import absolute_import
+import pymba.vimbastructure as structs
+from .vimbadll import VimbaDLL
+from .vimbaexception import VimbaException
+from .vimbasystem import VimbaSystem
+from .vimbacamera import VimbaCamera
+from .vimbainterface import VimbaInterface
 from ctypes import *
 
 
@@ -74,7 +75,6 @@ class Vimba(object):
                                                 byref(numFound),
                                                 sizeof(dummyInterfaceInfo))
             if errorCode != 0:
-                print errorCode
                 raise VimbaException(errorCode)
 
             numInterfaces = numFound.value
@@ -112,7 +112,6 @@ class Vimba(object):
                                              byref(numFound),
                                              sizeof(dummyCameraInfo))
             if errorCode != 0 and errorCode != -9:
-                print errorCode
                 raise VimbaException(errorCode)
 
             numCameras = numFound.value
@@ -153,7 +152,7 @@ class Vimba(object):
 
         :returns: list -- camera IDs for available cameras.
         """
-        return list(camInfo.cameraIdString for camInfo in self._getCameraInfos())
+        return list(camInfo.cameraIdString.decode() for camInfo in self._getCameraInfos())
 
     def getInterfaceInfo(self, interfaceId):
         """

--- a/pymba/vimbacamera.py
+++ b/pymba/vimbacamera.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-import vimbastructure as structs
-from vimbaobject import VimbaObject
-from vimbaexception import VimbaException
-from vimbaframe import VimbaFrame
-from vimbadll import VimbaDLL
+from __future__ import absolute_import
+import pymba.vimbastructure as structs
+from .vimbaobject import VimbaObject
+from .vimbaexception import VimbaException
+from .vimbaframe import VimbaFrame
+from .vimbadll import VimbaDLL
 from ctypes import *
 
 # camera features are automatically readable as object attributes.
@@ -18,7 +19,7 @@ class VimbaCamera(VimbaObject):
 
     @property
     def cameraIdString(self):
-        return self._cameraIdString
+        return self._cameraIdString.decode()
 
     # own handle is inherited as self._handle
     def __init__(self, cameraIdString):
@@ -27,7 +28,7 @@ class VimbaCamera(VimbaObject):
         super(VimbaCamera, self).__init__()
 
         # set ID
-        self._cameraIdString = cameraIdString
+        self._cameraIdString = cameraIdString.encode()
 
         # set own info
         self._info = self._getInfo()

--- a/pymba/vimbadll.py
+++ b/pymba/vimbadll.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
-import vimbastructure as structs
-from vimbaexception import VimbaException
+from __future__ import absolute_import
+
 from sys import platform as sys_plat
 import platform
 import os
 from ctypes import *
+
+import pymba.vimbastructure as structs
+from .vimbaexception import VimbaException
 
 if sys_plat == "win32":
 
@@ -16,24 +19,19 @@ if sys_plat == "win32":
             raise IOError("VimbaC.dll not found.")
         return dlls[-1]
 
-    from ctypes.util import find_msvcrt
-    _cruntime = cdll.LoadLibrary(find_msvcrt())
     if '64' in platform.architecture()[0]:
         vimbaC_path = find_win_dll(64)
     else:
         vimbaC_path = find_win_dll(32)
     dll_loader = windll
 else:
-    _cruntime = CDLL("libc.so.6")
+
     dll_loader = cdll
     assert os.environ.get(
         "GENICAM_GENTL64_PATH"), "you need your GENICAM_GENTL64_PATH environment set.  Make sure you have Vimba installed, and you have loaded the /etc/profile.d/ scripts"
     vimba_dir = "/".join(os.environ.get("GENICAM_GENTL64_PATH").split("/")
                          [1:-3])
     vimbaC_path = "/" + vimba_dir + "/VimbaC/DynamicLib/x86_64bit/libVimbaC.so"
-
-with open(vimbaC_path) as thefile:
-    pass  # NJO i think this is kind of like an os.exists ?
 
 
 class VimbaDLL(object):
@@ -411,29 +409,16 @@ class VimbaC_MemoryBlock(object):
     neatly with C memory allocations.
     """
 
-    # C runtime DLL
-    _crtDLL = _cruntime
-
     @property
     def block(self):
-        return self._block
+        return c_void_p(addressof(self._block))
 
     def __init__(self, blockSize):
-
-        # assign memory block
-        malloc = self._crtDLL.malloc
-        malloc.argtypes = (c_size_t,)
-        malloc.restype = c_void_p
-        self._block = malloc(blockSize)        # todo check for NULL on failure
+        self._block = create_string_buffer(blockSize)
 
         # this seems to be None if too much memory is requested
         if self._block is None:
             raise VimbaException(-51)
 
     def __del__(self):
-
-        # free memory block
-        free = self._crtDLL.free
-        free.argtypes = (c_void_p,)
-        free.restype = None
-        free(self._block)
+        del self._block

--- a/pymba/vimbaexception.py
+++ b/pymba/vimbaexception.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import exceptions
 
 
 class VimbaException(Exception):

--- a/pymba/vimbafeature.py
+++ b/pymba/vimbafeature.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-import vimbastructure as structs
-from vimbaexception import VimbaException
-from vimbadll import VimbaDLL
+from __future__ import absolute_import
+import pymba.vimbastructure as structs
+from .vimbaexception import VimbaException
+from .vimbadll import VimbaDLL
 from ctypes import *
 
 # class may extend a generic Vimba entity class one day...
@@ -15,7 +16,7 @@ class VimbaFeature(object):
 
     @property
     def name(self):
-        return self._name
+        return self._name.decode()
 
     @property
     def handle(self):
@@ -37,7 +38,7 @@ class VimbaFeature(object):
     def __init__(self, name, handle):
 
         # set name and handle
-        self._name = name
+        self._name = name.encode()
         self._handle = handle
 
         # set own info
@@ -178,7 +179,7 @@ class VimbaFeature(object):
         if errorCode != 0:
             raise VimbaException(errorCode)
 
-        return valueToGet.value
+        return valueToGet.value.decode()
 
     def _setEnumFeature(self, valueToSet):
         """
@@ -189,7 +190,7 @@ class VimbaFeature(object):
 
         errorCode = VimbaDLL.featureEnumSet(self._handle,
                                             self._name,
-                                            valueToSet)
+                                            valueToSet.encode())
         if errorCode != 0:
             raise VimbaException(errorCode)
 
@@ -212,8 +213,7 @@ class VimbaFeature(object):
                                               byref(sizeFilled))
         if errorCode != 0:
             raise VimbaException(errorCode)
-
-        return valueToGet.value
+        return valueToGet.value.decode()
 
     def _setStringFeature(self, valueToSet):
         """
@@ -224,7 +224,7 @@ class VimbaFeature(object):
 
         errorCode = VimbaDLL.featureStringSet(self._handle,
                                               self._name,
-                                              valueToSet)
+                                              valueToSet.encode())
         if errorCode != 0:
             raise VimbaException(errorCode)
 

--- a/pymba/vimbaframe.py
+++ b/pymba/vimbaframe.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import vimbastructure as structs
-from vimbaexception import VimbaException
-from vimbadll import VimbaDLL
-from vimbadll import VimbaC_MemoryBlock
+from __future__ import absolute_import
+import pymba.vimbastructure as structs
+from .vimbaexception import VimbaException
+from .vimbadll import VimbaDLL
+from .vimbadll import VimbaC_MemoryBlock
 from ctypes import *
 
 """

--- a/pymba/vimbainterface.py
+++ b/pymba/vimbainterface.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import vimbastructure as structs
-from vimbaobject import VimbaObject
-from vimbaexception import VimbaException
-from vimbadll import VimbaDLL
+from __future__ import absolute_import
+import pymba.vimbastructure as structs
+from .vimbaobject import VimbaObject
+from .vimbaexception import VimbaException
+from .vimbadll import VimbaDLL
 from ctypes import *
 
 # interface features are automatically readable as object attributes.

--- a/pymba/vimbaobject.py
+++ b/pymba/vimbaobject.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import vimbastructure as structs
-from vimbaexception import VimbaException
-from vimbafeature import VimbaFeature
-from vimbadll import VimbaDLL
+from __future__ import absolute_import
+import pymba.vimbastructure as structs
+from .vimbaexception import VimbaException
+from .vimbafeature import VimbaFeature
+from .vimbadll import VimbaDLL
 from ctypes import *
 
 
@@ -106,7 +107,7 @@ class VimbaObject(object):
 
         :returns: list -- feature names for available features.
         """
-        return list(featInfo.name for featInfo in self._getFeatureInfos())
+        return list(featInfo.name.decode() for featInfo in self._getFeatureInfos())
 
     def getFeatureInfo(self, featureName):
         """
@@ -119,7 +120,7 @@ class VimbaObject(object):
         # don't do this live as we already have this info
         # return info object, if it exists
         for featInfo in self._getFeatureInfos():
-            if featInfo.name == featureName:
+            if featInfo.name.decode() == featureName:
                 return featInfo
         # otherwise raise error
         raise VimbaException(-53)
@@ -136,7 +137,7 @@ class VimbaObject(object):
         :returns: tuple -- range as (feature min value, feature max value).
         """
         # can't cache this, need to look it up live
-        return VimbaFeature(featureName, self._handle).range
+        return VimbaFeature(featureName.encode(), self._handle).range
 
     def runFeatureCommand(self, featureName):
         """
@@ -146,7 +147,7 @@ class VimbaObject(object):
         """
         # run a command
         errorCode = VimbaDLL.featureCommandRun(self._handle,
-                                               featureName)
+                                               featureName.encode())
         if errorCode != 0:
             raise VimbaException(errorCode)
 

--- a/pymba/vimbasystem.py
+++ b/pymba/vimbasystem.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from vimbaobject import VimbaObject
-from ctypes import *
+from __future__ import absolute_import
+from .vimbaobject import VimbaObject
+from ctypes import c_void_p
 
 # system features are automatically readable as attributes.
 


### PR DESCRIPTION
This adds basic support for python 3. The main points handled here are
- Absolute imports fixed
- Unicode handling, where I tried to push all encoding into pymba
- VimbaC_MemoryBlock has been rewritten, since python 3.5 has no monolithic C run time anymore.

The code works for my application and should support Python 2 and 3 at the same time.
