### PR TITLE
Update vimbaobject.py

### DIFF
--- a/pymba/vimbaobject.py
+++ b/pymba/vimbaobject.py
@@ -73,8 +73,8 @@ class VimbaObject(object):
             # call once to get number of available features
             # Vimba DLL will return an error code
             errorCode = VimbaDLL.featuresList(self._handle,
-                                              byref(dummyFeatureInfo),
-                                              999,
+                                              None,
+                                              0,
                                               byref(numFound),
                                               sizeof(dummyFeatureInfo))
             if errorCode != 0:


### PR DESCRIPTION
This is to fix the problem of Python crashing ([#23](https://github.com/morefigs/pymba/issues/23), [#19](https://github.com/morefigs/pymba/issues/19)) for Vimba versions later than 1.3, proposed by Bill at AVT.  The earlier fix "can corrupt random memory up to 999* the size of the FeatureInfo struct"

I was in contact with Bill at AVT and having the same problems of Python crashing, with Python 2.7 and Vimba DLL version 1.5. The fix solves the issue for me. 