### PR TITLE
OpenCV example fix. Added line setting pixel format to Mono8.

### DIFF
--- a/pymba/tests/opencv_example.py
+++ b/pymba/tests/opencv_example.py
@@ -38,6 +38,9 @@ with Vimba() as vimba:
     # set the value of a feature
     camera0.AcquisitionMode = 'SingleFrame'
 
+    #set pixel format
+    camera0.PixelFormat="Mono8"    
+
     # create new frames for the camera
     frame0 = camera0.getFrame()    # creates a frame
     frame1 = camera0.getFrame()    # creates a second frame


### PR DESCRIPTION
The example saves greyscale images but the camera is not set for that mode. If the camera was configured for BGR8Packed mode before it saves images like this:

![foo0](https://cloud.githubusercontent.com/assets/1056375/14832354/34d8eabc-0bd0-11e6-86ec-1c2e93fc2b4d.png)

Instead of this:

![foo0](https://cloud.githubusercontent.com/assets/1056375/14832380/5990776c-0bd0-11e6-917f-8db5e90c68c2.png)

I am on Ubuntu 14.04.
