### PR TITLE
Correct Signature for frame callback

### DIFF
--- a/pymba/vimbadll.py
+++ b/pymba/vimbadll.py
@@ -45,10 +45,18 @@ with open(vimbaC_path) as thefile:
     pass  # NJO i think this is kind of like an os.exists ?
 
 
+# Callback Function Type
+if sys_plat == "win32":
+    CB_FUNCTYPE = WINFUNCTYPE
+else:
+    # Untested!
+    CB_FUNCTYPE = CFUNCTYPE
+
+
 class VimbaDLL(object):
 
     """
-    ctypes directives to make the wrapper class work cleanly, 
+    ctypes directives to make the wrapper class work cleanly,
     talks to VimbaC.dll
     """
     # a full list of Vimba API methods
@@ -320,8 +328,9 @@ class VimbaDLL(object):
                               c_uint32)                                # size of frame
 
     # callback for frame queue
-    frameDoneCallback = CFUNCTYPE(c_void_p,                         # camera handle
-                                  POINTER(structs.VimbaFrame))      # pointer to frame
+    frameDoneCallback = CB_FUNCTYPE(c_void_p,                     # Return Type
+                                    c_void_p,                     # Camera Hanlde
+                                    POINTER(structs.VimbaFrame))  # Pointer to frame
 
     # revoke a frame from the API
     frameRevoke = _vimbaDLL.VmbFrameRevoke

--- a/pymba/vimbaframe.py
+++ b/pymba/vimbaframe.py
@@ -105,7 +105,7 @@ class VimbaFrame(object):
         self._frameCallback = frameCallback
 
         # define a callback wrapper here so it doesn't bind self
-        def frameCallbackWrapper(p_frame):
+        def frameCallbackWrapper(cam_handle, p_frame):
             # call the user's callback with the self bound outside the wrapper
             # ignore the frame pointer since we already know the callback
             # refers to this frame
@@ -115,8 +115,7 @@ class VimbaFrame(object):
             self._frameCallbackWrapper_C = None
         else:
             # keep a reference to prevent gc issues
-            self._frameCallbackWrapper_C = \
-                VimbaDLL.frameDoneCallback(frameCallbackWrapper)
+            self._frameCallbackWrapper_C = VimbaDLL.frameDoneCallback(frameCallbackWrapper)
 
         errorCode = VimbaDLL.captureFrameQueue(self._handle,
                                                byref(self._frame),


### PR DESCRIPTION
This pull request fixes the signature for the frame callback and resolves issue #8.

The code was only tested on Windos as I don't have access to another machine at the moment. 

A code example using the frame callback can be found here: https://gist.github.com/jrast/e5965e27d1b201b4e33677077bb8827b

Expected behaviour of the example:
 - Two pictures should be taken with a delay of 2 seconds
 - The Text printed by the callback should be two times the same (as the frame is reused)
 - The fist image should be displayed in the first axis, the second in the second axis
