### PR TITLE
Fixed _getIntrerfaceInfos() to avoid python crash

### DIFF
--- a/pymba/vimba.py
+++ b/pymba/vimba.py
@@ -63,17 +63,15 @@ class Vimba(object):
         """
         if self._interfaceInfos is None:
             # args
-            dummyInterfaceInfo = structs.VimbaInterfaceInfo()
             numFound = c_uint32(-1)
 
             # call once just to get the number of interfaces
             # Vimba DLL will return an error code
-            errorCode = VimbaDLL.interfacesList(byref(dummyInterfaceInfo),
+            errorCode = VimbaDLL.interfacesList(None,
                                                 0,
                                                 byref(numFound),
-                                                sizeof(dummyInterfaceInfo))
+                                                sizeof(structs.VimbaInterfaceInfo))
             if errorCode != 0:
-                print errorCode
                 raise VimbaException(errorCode)
 
             numInterfaces = numFound.value
@@ -86,7 +84,7 @@ class Vimba(object):
             errorCode = VimbaDLL.interfacesList(interfaceInfoArray,
                                                 numInterfaces,
                                                 byref(numFound),
-                                                sizeof(dummyInterfaceInfo))
+                                                sizeof(structs.VimbaInterfaceInfo))
             if errorCode != 0:
                 raise VimbaException(errorCode)
             self._interfaceInfos = list(


### PR DESCRIPTION
This pull request fixes the crash mentioned in issue #34 

Code used to test the new implementation:

``` python
from pymba import Vimba

print("Starting Vimba")
vimba = Vimba()
vimba.startup()

infos = vimba._getInterfaceInfos()
for i in infos:
    for f in i.getFieldNames():
        print(f, getattr(i, f))

print("Vimba Shutdown")
vimba.shutdown()
```

PS: Last pull request for today...
