### PR TITLE
Fix for retrieving list of interfaces.

### DIFF
--- a/pymba/vimba.py
+++ b/pymba/vimba.py
@@ -68,7 +68,7 @@ class Vimba(object):
 
             # call once just to get the number of interfaces
             # Vimba DLL will return an error code
-            errorCode = VimbaDLL.interfacesList(byref(dummyInterfaceInfo),
+            errorCode = VimbaDLL.interfacesList(None,
                                                 0,
                                                 byref(numFound),
                                                 sizeof(dummyInterfaceInfo))


### PR DESCRIPTION
Sending in None as reference explicitly tells the DLL we're only interested in the number of interfaces available. I was having crashes with this request otherwise.

Note: I tested and verified this with Vimba 2.0. Perhaps the issue doesn't arise with older versions, but the documentation seems to indicate that this is the intended method all along.