### PR TITLE
Changed the import of vimbastructure

### DIFF
--- a/pymba/vimba.py
+++ b/pymba/vimba.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import pymba.vimbastructure as structs
+from . import vimbastructure as structs
 from .vimbadll import VimbaDLL
 from .vimbaexception import VimbaException
 from .vimbasystem import VimbaSystem

--- a/pymba/vimbacamera.py
+++ b/pymba/vimbacamera.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import pymba.vimbastructure as structs
+from . import vimbastructure as structs
 from .vimbaobject import VimbaObject
 from .vimbaexception import VimbaException
 from .vimbaframe import VimbaFrame

--- a/pymba/vimbadll.py
+++ b/pymba/vimbadll.py
@@ -6,7 +6,7 @@ import platform
 import os
 from ctypes import *
 
-import pymba.vimbastructure as structs
+from . import vimbastructure as structs
 from .vimbaexception import VimbaException
 
 if sys_plat == "win32":

--- a/pymba/vimbafeature.py
+++ b/pymba/vimbafeature.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import pymba.vimbastructure as structs
+from . import vimbastructure as structs
 from .vimbaexception import VimbaException
 from .vimbadll import VimbaDLL
 from ctypes import *

--- a/pymba/vimbaframe.py
+++ b/pymba/vimbaframe.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import pymba.vimbastructure as structs
+from . import vimbastructure as structs
 from .vimbaexception import VimbaException
 from .vimbadll import VimbaDLL
 from .vimbadll import VimbaC_MemoryBlock

--- a/pymba/vimbainterface.py
+++ b/pymba/vimbainterface.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import pymba.vimbastructure as structs
+from . import vimbastructure as structs
 from .vimbaobject import VimbaObject
 from .vimbaexception import VimbaException
 from .vimbadll import VimbaDLL

--- a/pymba/vimbaobject.py
+++ b/pymba/vimbaobject.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import pymba.vimbastructure as structs
+from . import vimbastructure as structs
 from .vimbaexception import VimbaException
 from .vimbafeature import VimbaFeature
 from .vimbadll import VimbaDLL


### PR DESCRIPTION
I changed the way vimbastructure is imported to guarantee that a relative import is performed within the package. It allows to use the package portably (without running setup.py) or when it's stored on a distant server with a bunch of other packages.

Sorry for the delay, I understood I tried to push to morefigs/pymba and wondered why I couldn't ...