### PR TITLE
Search path for VimbaC DLL extended

### DIFF
--- a/pymba/vimbadll.py
+++ b/pymba/vimbadll.py
@@ -25,6 +25,11 @@ if sys_plat == "win32":
                     if os.path.isfile(candidate):
                         dlls.append(candidate)
         if not dlls:
+            if 'VIMBA_HOME' in os.environ:
+                candidate = os.environ ['VIMBA_HOME'] + '\VimbaC\Bin\Win%i\VimbaC.dll' % (arch)
+                if os.path.isfile(candidate):
+                    dlls.append(candidate)
+        if not dlls:
             raise IOError("VimbaC.dll not found.")
         return dlls[-1]
 


### PR DESCRIPTION
At least for Windows the Vimba installer sets the VIMBA_HOME environment variable (if this is not switched off manually) which can be used to locate the VimbaC.dll. This is handy if Vimba is not installed in the default folder.