### PR TITLE
Searching libVimbaC.so failed

### DIFF
--- a/pymba/vimbadll.py
+++ b/pymba/vimbadll.py
@@ -45,27 +45,27 @@ else:
     if 'x86_64' in os.uname()[4]:
         assert os.environ.get(
             "GENICAM_GENTL64_PATH"), "you need your GENICAM_GENTL64_PATH environment set.  Make sure you have Vimba installed, and you have loaded the /etc/profile.d/ scripts"
-        vimba_dir = "/".join(os.environ.get("GENICAM_GENTL64_PATH").split("/")
-                             [1:-3])
+        tlPath = [p for p in os.environ.get("GENICAM_GENTL64_PATH").split(":") if p][0]
+        vimba_dir = "/".join(tlPath.split("/")[1:-3])
         vimbaC_path = "/" + vimba_dir + "/VimbaC/DynamicLib/x86_64bit/libVimbaC.so"
     elif 'x86_32' in os.uname()[4]:
         print("Warning: x86_32 reached!")
         assert os.environ.get(
             "GENICAM_GENTL32_PATH"), "you need your GENICAM_GENTL32_PATH environment set.  Make sure you have Vimba installed, and you have loaded the /etc/profile.d/ scripts"
-        vimba_dir = "/".join(os.environ.get("GENICAM_GENTL32_PATH").split("/")
-                             [1:-3])
+        tlPath = [p for p in os.environ.get("GENICAM_GENTL32_PATH").split(":") if p][0]
+        vimba_dir = "/".join(tlPath.split("/")[1:-3])
         vimbaC_path = "/" + vimba_dir + "/VimbaC/DynamicLib/x86_32bit/libVimbaC.so"
     elif 'arm' in os.uname()[4]:
         assert os.environ.get(
             "GENICAM_GENTL32_PATH"), "you need your GENICAM_GENTL32_PATH environment set.  Make sure you have Vimba installed, and you have loaded the /etc/profile.d/ scripts"
-        vimba_dir = "/".join(os.environ.get("GENICAM_GENTL32_PATH").split("/")
-                             [1:-3])
+        tlPath = [p for p in os.environ.get("GENICAM_GENTL32_PATH").split(":") if p][0]
+        vimba_dir = "/".join(tlPath.split("/")[1:-3])
         vimbaC_path = "/" + vimba_dir + "/VimbaC/DynamicLib/arm_32bit/libVimbaC.so"    
     elif 'aarch64' in os.uname()[4]:
         assert os.environ.get(
             "GENICAM_GENTL64_PATH"), "you need your GENICAM_GENTL64_PATH environment set.  Make sure you have Vimba installed, and you have loaded the /etc/profile.d/ scripts"
-        vimba_dir = "/".join(os.environ.get("GENICAM_GENTL64_PATH").split("/")
-                             [1:-3])
+        tlPath = [p for p in os.environ.get("GENICAM_GENTL32_PATH").split(":") if p][0]
+        vimba_dir = "/".join(tlPath.split("/")[1:-3])
         vimbaC_path = "/" + vimba_dir + "/VimbaC/DynamicLib/arm_64bit/libVimbaC.so"
     else:
         raise ValueError("Pymba currently doesn't support %s" % os.uname()[4])


### PR DESCRIPTION
While working with Linux ARM I noticed that locating the VimbaC library failed if more than one TL is registered with the GENICAM_GENTL environment variable, i.e. the path contains more than one entry. So, I added some code for splitting the path and taking the first entry before setting vimba_dir.