### PR TITLE
fix double-encoding bug in getFeatureRange

### DIFF
--- a/pymba/vimbaobject.py
+++ b/pymba/vimbaobject.py
@@ -138,7 +138,7 @@ class VimbaObject(object):
                   list -- names of possible enum values (for enum features only).
         """
         # can't cache this, need to look it up live
-        return VimbaFeature(featureName.encode(), self._handle).range
+        return VimbaFeature(featureName, self._handle).range
 
     def runFeatureCommand(self, featureName):
         """


### PR DESCRIPTION
__init__ of VimbaFeature already runs .encode on the input string. Doing it twice results in an error as bytes can not be decoded.