### PR TITLE
implement VimbaFrame.getTimestamp and VimbaFrame.getReceiveStatus

### DIFF
--- a/pymba/vimba_frame.py
+++ b/pymba/vimba_frame.py
@@ -173,3 +173,11 @@ class VimbaFrame(object):
         except NameError as e:
             print('install numpy to use this method or use getBufferByteData instead')
             raise e
+
+
+    def getTimestamp(self):
+        return self._frame.timestamp
+
+
+    def getReceiveStatus(self):
+        return self._frame.receiveStatus


### PR DESCRIPTION
Hi, 
I find the following 2 functions implemented in my fork useful.
getTimestamp is useful to measure latency and to timestamp frame
getReceiveStatus is needed to discard broken frames

See snippet below for example

```
            self._logger.debug("Got frame %d at time %.3f" % (
                self._counter, frame.getTimestamp() /
                self._timeStampTickFrequency))
            if frame.getReceiveStatus() == Vimba.FRAME_STATUS_COMPLETE:
                frame_data = frame.getBufferByteData()
                img = np.ndarray(buffer=frame_data,
                                 dtype=self._dtype,
                                 shape=(frame.height, frame.width))
                self._lastValidFrame= CameraFrame(img, counter=self._counter)
                self._notifyListenersAboutNewFrame()
                self._counter += 1
            else:
                self._logger.warn(
                    "Frame status not complete. "
                    "Try to reduce streamBytesPerSecond value")
```
