### PR TITLE
Fixed erroneous package path in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='pymba',
       author_email='morefigs@gmail.com',
       url='https://github.com/morefigs/pymba',
       license='MIT',
-      packages=['pymba', 'pymba.tests'],
+      packages=['pymba', 'tests'],
       zip_safe=False,
       requires=['numpy'],
       )


### PR DESCRIPTION
The package path in `setup.py` was not updated to reflect the changes made to the folder structure some time ago. This breaks the install process for `python setup.py install`. This PR solves the problem.

Cheers!