### PR TITLE
Feature/load xml conf

### DIFF
--- a/examples/camera/list_feature_infos.py
+++ b/examples/camera/list_feature_infos.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
     with Vimba() as vimba:
         camera = vimba.camera(0)
         camera.open()
-
+        camera.load_config(b'gabri.xml')
         for feature_name in camera.feature_names():
             feature = camera.feature(feature_name)
             print(feature.info)

--- a/examples/camera/load_xml_config.py
+++ b/examples/camera/load_xml_config.py
@@ -6,8 +6,5 @@ if __name__ == '__main__':
     with Vimba() as vimba:
         camera = vimba.camera(0)
         camera.open()
-        for feature_name in camera.feature_names():
-            feature = camera.feature(feature_name)
-            print(feature.info)
-
+        camera.load_config(b'sample_config.xml')
         camera.close()

--- a/pymba/camera.py
+++ b/pymba/camera.py
@@ -126,6 +126,11 @@ class Camera(VimbaObject):
         if error:
             raise VimbaException(error)
 
+    def load_config(self, xml_conf_path: str):
+        error = vimba_c.vmb_camera_load_settings(self._handle, xml_conf_path, None, 0)
+        if error:
+            raise VimbaException(error)
+    
     def revoke_all_frames(self):
         """
         Revoke all frames assigned to the camera.

--- a/pymba/vimba_c.py
+++ b/pymba/vimba_c.py
@@ -244,6 +244,13 @@ vmb_camera_close = _vimba_lib.VmbCameraClose
 vmb_camera_close.restype = c_int32
 vmb_camera_close.argtypes = (c_void_p,)
 
+vmb_camera_load_settings = _vimba_lib.VmbCameraSettingsLoad
+vmb_camera_load_settings.restype = c_int32
+vmb_camera_load_settings.argtypes = (c_void_p,
+                            c_char_p,
+                            c_void_p,
+                            c_uint32)
+
 vmb_features_list = _vimba_lib.VmbFeaturesList
 vmb_features_list.restype = c_int32
 vmb_features_list.argtypes = (c_void_p,


### PR DESCRIPTION
Adds a dummy implementation of VmbCameraSettingsLoad. I needed it only to be able to load an xml config file created with VimbaViewer on a camera. So, It works just with default/NULL arguments and I'm ignoring the 'settings struct' parameter.
I don't know if it's enough to be merged, but it may be helpful for others like me who really need this feature.